### PR TITLE
update link for ncalc transforms

### DIFF
--- a/astro/staticwebapp.config.json
+++ b/astro/staticwebapp.config.json
@@ -172,7 +172,7 @@
     },
     {
       "route": "/en/tutorials/community-guides/expression-syntax-guide.html",
-      "redirect": "https://docs.mobiflight.com/features/modifiers/transform/",
+      "redirect": "https://docs.mobiflight.com/guides/modifying-values-with-ncalc/",
       "statusCode": 301
     }
   ],


### PR DESCRIPTION
Follow up on #19 which suggest a slightly wrong link. This time it redirects to: 
https://docs.mobiflight.com/guides/modifying-values-with-ncalc/

as requested in https://github.com/MobiFlight/MobiFlight-Connector/issues/2974
